### PR TITLE
delete duplicated n' ん

### DIFF
--- a/dvorakjp_prime.txt
+++ b/dvorakjp_prime.txt
@@ -564,7 +564,6 @@ rhq	りょん
 rhj	りぇん
 rhk	りゅん
 rhx	りぃん
-n'	ん
 nn	ん
 n	ん
 xn	ん


### PR DESCRIPTION
以下の2種が存在した。

* Google日本語入力由来の `n'	ん`
* DvorakJPの二重母音拡張による `n'	ない`

README.mdの通り、Google日本語入力由来の`'` による拡張はノーヒントで分かりづらく、また二重母音拡張と重複する為、 `n'	ん` を削除する。
