### PR TITLE
delete duplicated fu ふ

### DIFF
--- a/dvorakjp_prime.txt
+++ b/dvorakjp_prime.txt
@@ -827,7 +827,6 @@ nx	にん
 ha	は
 hi	ひ
 hu	ふ
-fu	ふ
 he	へ
 ho	ほ
 h'	はい


### PR DESCRIPTION
`fu ふ` が2箇所に記述されていたので片方を削除した。