### PR TITLE
GitHub Actions による CI ワークフローを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Rust ツールチェインをセットアップ
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: キャッシュを復元
+        uses: Swatinem/rust-cache@v2
+
+      - name: フォーマットを確認
+        run: cargo fmt --check
+
+      - name: clippy を実行
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: ビルド
+        run: cargo build --verbose
+
+      - name: テスト
+        run: cargo test --verbose
+
+      - name: ローマ字テーブルを生成して差分がないことを確認
+        run: |
+          cargo run -- build roman-table
+          git diff --exit-code outputs/


### PR DESCRIPTION
## 概要

このリポジトリには CI が無く、dependabot の PR に一切チェックが走っていませんでした。そのため依存更新のたびに手元でビルド・テストを回す必要があり、直近の 5 件（#70〜#74）も手動で検証してマージしています。GitHub Actions でビルドとテストを自動化し、PR 上で可否を判断できるようにします。

## 変更内容

- `.github/workflows/ci.yml` を追加
  - `main` への push と、すべての Pull Request で実行
  - `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo build` / `cargo test` を実行
  - `cargo run -- build roman-table` を実行し、`outputs/` に差分が出ないことを確認（コミット済みの生成物と実際の出力のズレを検知する）
  - `Swatinem/rust-cache` でビルドキャッシュを利用
  - 同一ブランチの実行中ジョブは `concurrency` でキャンセル
  - `permissions: contents: read` に制限
- `.github/dependabot.yml` に `github-actions` エコシステムを追加
  - CI で使う actions（`actions/checkout`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`）も自動更新の対象になる

なお、ネットワークアクセスが必要な `build with-emoji` は CI では実行していません。

## 確認方法

ワークフローの各ステップを手元で実行し、すべて成功することを確認済みです。

```bash
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo build --verbose
cargo test --verbose
cargo run -- build roman-table && git diff --exit-code outputs/
```

- テストは 6 件すべてパス
- `outputs/` に差分なし

この PR 自体にも CI が走るため、Checks が green になることで最終確認となります。
