### PR TITLE
バージョン 2.1.0 をリリース

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dvorakjp-romantable"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dvorakjp-romantable"
 edition = "2024"
-version = "2.0.0"
+version = "2.1.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Releases
 
+## Version 2.1.0 (2026-08-10)
+
+- azooKey で `nh` 始まりの入力（にゃ行）に対応
+- GitHub Actions による CI ワークフローを追加
+
 ## Version 2.0.0 (2026-02-23)
 
 - azooKey に対応


### PR DESCRIPTION
## 概要

2.0.0 以降の変更をまとめて 2.1.0 としてリリースする。

## 変更内容

- `Cargo.toml` / `Cargo.lock` のバージョンを 2.1.0 に更新
- `RELEASES.md` に 2.1.0 の変更履歴を追記

## 2.0.0 からの主な変更

- azooKey で `nh` 始まりの入力（にゃ行）に対応 (1731875)
- GitHub Actions による CI ワークフローを追加 (2d8df20, 1625b87)
- README にファイル構成セクションを追加 (ca553c4, 6f6eab1)
- 依存ライブラリの更新（dependabot）

## 確認方法

- `cargo test` が通ること
- `cargo run -- build roman-table` を実行しても `outputs/` に差分が出ないこと

## マージ後の作業

- `2.1.0` タグの作成と GitHub Release の公開

🤖 Generated with [Claude Code](https://claude.com/claude-code)