### PR TITLE
aws-lc-sys を 0.44.0 に更新してセキュリティ脆弱性を解消

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -76,14 +76,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -847,6 +848,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"


### PR DESCRIPTION
## 概要

Dependabot のセキュリティアラートで未対応だった `aws-lc-sys` の脆弱性 5 件を解消します。

`aws-lc-sys` は `reqwest` → `rustls` → `aws-lc-rs` 経由の推移的依存です。`aws-lc-rs` 1.15.4 が `aws-lc-sys` を 0.37 系に固定していたため、`aws-lc-rs` も併せて更新しています。

## 変更内容

- `aws-lc-sys` 0.37.0 → 0.44.0
- `aws-lc-rs` 1.15.4 → 1.18.0
- `pkg-config` 0.3.33 を追加（`aws-lc-sys` の新規ビルド依存）

`Cargo.lock` のみの変更で、`Cargo.toml` の直接依存に変更はありません。

## 対応するアラート

| GHSA | 深刻度 | 概要 | 修正版 |
| --- | --- | --- | --- |
| GHSA-9f94-5g5w-gf6r | High | CRL Distribution Point Scope Check Logic Error | 0.39.0 |
| GHSA-394x-vwmw-crm3 | High | X.509 Name Constraints Bypass via Wildcard/Unicode CN | 0.39.0 |
| GHSA-hfpc-8r3f-gw53 | High | PKCS7_verify Signature Validation Bypass | 0.38.0 |
| GHSA-65p9-r9h6-22vj | High | Timing Side-Channel in AES-CCM Tag Verification | 0.38.0 |
| GHSA-vw5v-4f2q-w9xf | High | PKCS7_verify Certificate Chain Validation Bypass | 0.38.0 |

## 動作確認

- `cargo build` 成功
- `cargo test` 6 件すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)